### PR TITLE
Add priority field for custom links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ You should have received a copy of the GNU General Public License along with thi
 
 ### 1.00
 * Initial release.
+
+### 1.1
+* Added separate tab for front-end links.
+
+### 1.2
+* Added priority option for each link and instructions on settings page.


### PR DESCRIPTION
## Summary
- allow prioritizing links via numeric priority fields
- show instructions on the settings page
- keep backwards compatibility by upgrading stored options
- document the new feature in the changelog

## Testing
- `php -l kiss-wp-admin-menu-useful-links.php`

------
https://chatgpt.com/codex/tasks/task_b_6871b5cf38cc832eb62ad8aff696f3c9