### PR TITLE
Enhance plugin settings and security

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ You should have received a copy of the GNU General Public License along with thi
 
 ## Changelog
 
+### 1.4
+* Added nonce verification and option caching.
+* Improved settings UI and security.
+
 ### 1.3
 * Added an upgrade routine to set a default priority for links from older versions.
 


### PR DESCRIPTION
## Summary
- bump version to 1.4
- cache options with transients
- split settings init into focused functions
- add nonce handling and link test button
- add JS storage safety and helper functions
- improve help text for priority fields
- fix undefined variable when adding links
- add PHP type hints and docs
- update changelog

## Testing
- `php -l kiss-wp-admin-menu-useful-links.php`

------
https://chatgpt.com/codex/tasks/task_b_688985d703d0832ea0fa6a18b6b6331f